### PR TITLE
Fix observation list screen closing brace

### DIFF
--- a/mobile/lib/features/scan/observation_list_screen.dart
+++ b/mobile/lib/features/scan/observation_list_screen.dart
@@ -100,4 +100,3 @@ class ObservationListScreen extends StatelessWidget {
     }
   }
 }
-}


### PR DESCRIPTION
## Summary
- remove the redundant trailing brace from the observation list screen so the file compiles again

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1aae99a648331a32af3be891e2328