### PR TITLE
Use conditional camera initializer

### DIFF
--- a/mobile/lib/camera_initializer_io.dart
+++ b/mobile/lib/camera_initializer_io.dart
@@ -1,0 +1,3 @@
+import 'dart:io' show Platform;
+
+bool get shouldInitializeCamera => Platform.isAndroid || Platform.isIOS;

--- a/mobile/lib/camera_initializer_stub.dart
+++ b/mobile/lib/camera_initializer_stub.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+bool get shouldInitializeCamera => kIsWeb;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,6 +1,7 @@
-import 'dart:io' show Platform;
+import 'camera_initializer_stub.dart'
+    if (dart.library.io) 'camera_initializer_io.dart'
+    as cameraInitializer;
 import 'package:camera/camera.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'data/models/observation.dart';
 import 'data/services/inventory_service.dart';
@@ -12,7 +13,7 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   List<CameraDescription> cameras = const [];
-  if (kIsWeb || Platform.isAndroid || Platform.isIOS) {
+  if (cameraInitializer.shouldInitializeCamera) {
     try {
       cameras = await availableCameras();
     } catch (_) {


### PR DESCRIPTION
## Summary
- add platform-specific camera initializer helpers so web builds avoid importing `dart:io`
- update the camera setup guard in `main.dart` to use the conditional helper

## Testing
- `flutter analyze` *(fails: `flutter` not found in container)*
- `flutter build web` *(fails: `flutter` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d21d92948c83318b8e57c75cfda2ec