### PR TITLE
Integrate add/edit item flow with inventory service

### DIFF
--- a/mobile/lib/features/inventory/add_item_screen.dart
+++ b/mobile/lib/features/inventory/add_item_screen.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import '../../data/models/item.dart';
 
 /// A screen for adding or editing inventory items.
+typedef ItemSaveCallback = Future<void> Function(Item item, bool isEditing);
+
 class AddItemScreen extends StatefulWidget {
   final Item? item;
-  
-  const AddItemScreen({super.key, this.item});
+  final ItemSaveCallback onSave;
+
+  const AddItemScreen({super.key, this.item, required this.onSave});
 
   @override
   State<AddItemScreen> createState() => _AddItemScreenState();
@@ -209,7 +212,7 @@ class _AddItemScreenState extends State<AddItemScreen> {
     );
   }
 
-  void _saveItem() {
+  void _saveItem() async {
     if (!_formKey.currentState!.validate()) {
       return;
     }
@@ -225,7 +228,9 @@ class _AddItemScreenState extends State<AddItemScreen> {
       imageRef: '',
     );
 
-    // TODO: Save to database
+    await widget.onSave(item, widget.item != null);
+
+    if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(widget.item != null ? 'Item updated successfully' : 'Item added successfully'),

--- a/mobile/lib/features/inventory/inventory_screen.dart
+++ b/mobile/lib/features/inventory/inventory_screen.dart
@@ -60,6 +60,31 @@ class _InventoryScreenState extends State<InventoryScreen> {
 
   List<String> get _categories => _inventoryService.categories;
 
+  Future<void> _handleItemPersistence(Item item, bool isEditing) async {
+    if (isEditing) {
+      _inventoryService.updateItem(item);
+    } else {
+      _inventoryService.addItem(item);
+    }
+  }
+
+  Future<void> _openAddOrEditItem({Item? item}) async {
+    final result = await Navigator.of(context).push<Item>(
+      MaterialPageRoute(
+        builder: (_) => AddItemScreen(
+          item: item,
+          onSave: _handleItemPersistence,
+        ),
+      ),
+    );
+
+    if (!mounted) return;
+
+    if (result != null) {
+      _filterItems();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -68,11 +93,9 @@ class _InventoryScreenState extends State<InventoryScreen> {
         actions: [
           IconButton(
             icon: const Icon(Icons.add),
-            onPressed: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const AddItemScreen(),
-              ),
-            ),
+            onPressed: () {
+              _openAddOrEditItem();
+            },
           ),
         ],
       ),
@@ -217,6 +240,13 @@ class _InventoryScreenState extends State<InventoryScreen> {
           ],
         ),
         actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              _openAddOrEditItem(item: item);
+            },
+            child: const Text('Edit'),
+          ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
             child: const Text('Close'),

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -13,6 +13,12 @@ import 'package:mobile/data/services/inventory_service.dart';
 import 'package:mobile/data/models/observation.dart';
 import 'package:mobile/features/inventory/inventory_screen.dart';
 
+Finder _textFieldByLabel(String label) {
+  return find.byWidgetPredicate(
+    (widget) => widget is TextFormField && widget.decoration?.labelText == label,
+  );
+}
+
 void main() {
   group('Stone & Resin Inventory App Tests', () {
     testWidgets('Main app loads with bottom navigation', (WidgetTester tester) async {
@@ -51,6 +57,35 @@ void main() {
       // Should see inventory screen
       expect(find.text('Inventory'), findsOneWidget);
       expect(find.text('Search items...'), findsOneWidget);
+    });
+
+    testWidgets('Adding a new item updates the inventory list', (WidgetTester tester) async {
+      const testItemName = 'Widget Test Hammer';
+      const testSku = 'WT-123';
+
+      addTearDown(() {
+        final service = InventoryService();
+        final match = service.items.where((item) => item.name == testItemName);
+        if (match.isNotEmpty) {
+          service.removeItem(match.first.id);
+        }
+      });
+
+      await tester.pumpWidget(const MaterialApp(home: InventoryScreen()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(_textFieldByLabel('Item Name *'), testItemName);
+      await tester.enterText(_textFieldByLabel('SKU/Part Number *'), testSku);
+      await tester.enterText(_textFieldByLabel('Reorder Minimum *'), '7');
+
+      await tester.tap(find.text('Add Item'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(testItemName), findsOneWidget);
+      expect(find.textContaining(testSku), findsOneWidget);
     });
 
     testWidgets('Camera screen shows proper UI elements', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- inject a save callback into `AddItemScreen` so item submissions persist through the shared `InventoryService`
- update `InventoryScreen` to await add/edit flows, persist returned items, refresh filters, and expose an edit entry point from the details dialog
- add a widget test that exercises adding a new item and verifies it appears in the inventory list

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d21d9494008331bf5ed26190ebefcf